### PR TITLE
Swipe for reader view 71

### DIFF
--- a/src/ios/vfr/ReaderContentView.h
+++ b/src/ios/vfr/ReaderContentView.h
@@ -37,6 +37,10 @@
 
 - (void)contentView:(ReaderContentView *)contentView touchesBegan:(NSSet *)touches;
 
+@optional
+
+-(void)scrollViewEndedZoomingWithScrollView:(UIScrollView *)view atScale:(CGFloat)scale;
+
 @end
 
 @interface ReaderContentView : UIScrollView

--- a/src/ios/vfr/ReaderContentView.m
+++ b/src/ios/vfr/ReaderContentView.m
@@ -327,6 +327,11 @@ static inline CGFloat zoomScaleThatFits(CGSize target, CGSize source, CGFloat bf
 	{
 		if (self.zoomScale < realMaximumZoom) zoomBounced = NO;
 	}
+    
+    if ([self.message respondsToSelector:@selector(scrollViewEndedZoomingWithScrollView:atScale:)])
+    {
+        [self.message scrollViewEndedZoomingWithScrollView:scrollView atScale:scale]; // Refresh
+    }
 }
 
 - (void)scrollViewDidZoom:(UIScrollView *)scrollView

--- a/src/ios/vfr/ReaderMainPagebar.h
+++ b/src/ios/vfr/ReaderMainPagebar.h
@@ -54,8 +54,6 @@
     
     UIView *pageNumberView;
     
-    UIView *swipeForArticleView;
-    
     NSTimer *enableTimer;
     NSTimer *trackTimer;
 }

--- a/src/ios/vfr/ReaderMainPagebar.m
+++ b/src/ios/vfr/ReaderMainPagebar.m
@@ -205,38 +205,6 @@
         
         [self addSubview:pageNumberView]; // Add page numbers display view
         
-        CGRect swipeRect = CGRectMake(numberRect.origin.x - (numberRect.size.width /2), numberRect.origin.y + 3 + numberRect.size.height, numberRect.size.width * 2.0, numberRect.size.height);
-        swipeForArticleView = [[UIView alloc] initWithFrame:swipeRect];
-        
-        swipeForArticleView.autoresizesSubviews = NO;
-        swipeForArticleView.userInteractionEnabled = NO;
-        swipeForArticleView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-        swipeForArticleView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.4f];
-        
-        swipeForArticleView.layer.shadowOffset = CGSizeMake(0.0f, 0.0f);
-        swipeForArticleView.layer.shadowColor = [UIColor colorWithWhite:0.0f alpha:0.6f].CGColor;
-        swipeForArticleView.layer.shadowPath = [UIBezierPath bezierPathWithRect:pageNumberView.bounds].CGPath;
-        swipeForArticleView.layer.shadowRadius = 2.0f; swipeForArticleView.layer.shadowOpacity = 1.0f;
-        
-        CGRect articleTextRect = CGRectInset(swipeForArticleView.bounds, 4.0f, 2.0f); // Inset the text a bit
-        
-        UILabel* articleTextLabel = [[UILabel alloc] initWithFrame:articleTextRect]; // Page numbers label
-        articleTextLabel.text = @"Swipe up for Reader View";
-        
-        articleTextLabel.autoresizesSubviews = NO;
-        articleTextLabel.autoresizingMask = UIViewAutoresizingNone;
-        articleTextLabel.textAlignment = NSTextAlignmentCenter;
-        articleTextLabel.backgroundColor = [UIColor clearColor];
-        articleTextLabel.textColor = [UIColor whiteColor];
-        articleTextLabel.font = [UIFont systemFontOfSize:16.0f];
-        articleTextLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
-        articleTextLabel.shadowColor = [UIColor blackColor];
-        articleTextLabel.adjustsFontSizeToFitWidth = YES;
-        articleTextLabel.minimumScaleFactor = 0.75f;
-        
-        [swipeForArticleView addSubview:articleTextLabel]; // Add label view
-        
-        [self addSubview:swipeForArticleView]; // swipe for article text.
 
 		trackControl = [[ReaderTrackControl alloc] initWithFrame:self.bounds]; // Track control view
 

--- a/src/ios/vfr/SDVReaderMainPagebar.h
+++ b/src/ios/vfr/SDVReaderMainPagebar.h
@@ -11,6 +11,4 @@
 
 @interface SDVReaderMainPagebar : ReaderMainPagebar
 
-- (void)showSwipeForArticleViewLabel:(BOOL)show;
-
 @end

--- a/src/ios/vfr/SDVReaderMainPagebar.m
+++ b/src/ios/vfr/SDVReaderMainPagebar.m
@@ -31,10 +31,5 @@
     }
 }
 
-- (void)showSwipeForArticleViewLabel:(BOOL)show
-{
-    swipeForArticleView.hidden = !show;
-}
-
 
 @end

--- a/src/ios/vfr/SDVReaderViewController.h
+++ b/src/ios/vfr/SDVReaderViewController.h
@@ -19,7 +19,9 @@ typedef enum
     SDVReaderContentViewModeCoverDoublePage
 } SDVReaderContentViewMode;
 
-@interface SDVReaderViewController : ReaderViewController
+@interface SDVReaderViewController : ReaderViewController {
+    UIView *swipeForArticleView;
+}
 @property NSMutableDictionary *viewerOptions;
 @property int pagesPerScreen;
 @property SDVReaderContentViewMode viewMode;

--- a/src/ios/vfr/SDVReaderViewController.m
+++ b/src/ios/vfr/SDVReaderViewController.m
@@ -137,19 +137,22 @@
 {
     if ([mainPagebar isKindOfClass:[SDVReaderMainPagebar class]]) {
         SDVReaderMainPagebar* sdvPageBar = (SDVReaderMainPagebar *)mainPagebar;
-        [sdvPageBar showSwipeForArticleViewLabel:[self isCurrentPageArticle]];
-        
+
         if ([self isCurrentPageArticle]) {
             [self showReaderViewSwipe];
         } else {
-            [self hideReaderViewSwipe];
+            if (readerViewTimer != nil) {
+                [readerViewTimer invalidate];
+                readerViewTimer = nil;
+            }
+            swipeForArticleView.hidden = YES;
         }
     }
 }
 
 -(void)hideReaderViewSwipe
 {
-    [UIView animateWithDuration:2.0 delay:0.0
+    [UIView animateWithDuration:1.0 delay:0.0
         options:UIViewAnimationOptionCurveLinear | UIViewAnimationOptionAllowUserInteraction
                      animations:^(void)
         {
@@ -164,6 +167,7 @@
     
     if (readerViewTimer != nil) {
         [readerViewTimer invalidate];
+        readerViewTimer = nil;
     }
 }
 
@@ -174,8 +178,9 @@
     
     if (readerViewTimer != nil) {
         [readerViewTimer invalidate];
+        readerViewTimer = nil;
     }
-    readerViewTimer = [NSTimer scheduledTimerWithTimeInterval:5.0
+    readerViewTimer = [NSTimer scheduledTimerWithTimeInterval:3.0
                                                        target:self
                                                      selector:@selector(hideReaderViewSwipe)
                                                      userInfo:nil
@@ -430,45 +435,6 @@
 //         ];
 //    }
 //}
-
--(void)addSwipeUpForReaderView
-{
-    CGFloat screenWidth = self.view.frame.size.width;
-    CGRect theFrame = self.view.frame;
-    CGRect swipeRect = CGRectMake(screenWidth/4, STATUS_HEIGHT*3 + 10, screenWidth/2.0, STATUS_HEIGHT);
-    swipeForArticleView = [[UIView alloc] initWithFrame:swipeRect];
-    
-    swipeForArticleView.autoresizesSubviews = NO;
-    swipeForArticleView.userInteractionEnabled = NO;
-    swipeForArticleView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-    swipeForArticleView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.4f];
-    
-    swipeForArticleView.layer.shadowOffset = CGSizeMake(0.0f, 0.0f);
-    swipeForArticleView.layer.shadowColor = [UIColor colorWithWhite:0.0f alpha:0.6f].CGColor;
-    swipeForArticleView.layer.shadowPath = [UIBezierPath bezierPathWithRect:swipeForArticleView.bounds].CGPath;
-    swipeForArticleView.layer.shadowRadius = 2.0f; swipeForArticleView.layer.shadowOpacity = 1.0f;
-    
-    CGRect articleTextRect = CGRectInset(swipeForArticleView.bounds, 4.0f, 2.0f); // Inset the text a bit
-    
-    UILabel* articleTextLabel = [[UILabel alloc] initWithFrame:articleTextRect]; // Page numbers label
-    articleTextLabel.text = @"Swipe up for Reader View";
-    
-    articleTextLabel.autoresizesSubviews = NO;
-    articleTextLabel.autoresizingMask = UIViewAutoresizingNone;
-    articleTextLabel.textAlignment = NSTextAlignmentCenter;
-    articleTextLabel.backgroundColor = [UIColor clearColor];
-    articleTextLabel.textColor = [UIColor whiteColor];
-    articleTextLabel.font = [UIFont systemFontOfSize:16.0f];
-    articleTextLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
-    articleTextLabel.shadowColor = [UIColor blackColor];
-    articleTextLabel.adjustsFontSizeToFitWidth = YES;
-    articleTextLabel.minimumScaleFactor = 0.75f;
-    
-    [swipeForArticleView addSubview:articleTextLabel]; // Add label view
-    
-    [self.view addSubview:swipeForArticleView]; // swipe for article text.
-
-}
 
 // individual page number calculations on scroll for double page modes
 - (void)handleScrollViewDidEnd:(UIScrollView *)scrollView
@@ -1167,15 +1133,51 @@
     theScrollView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     theScrollView.backgroundColor = [UIColor blackColor]; theScrollView.delegate = self;
     [self.view addSubview:theScrollView];
-    
-    // Add Swipe View
-    [self addSwipeUpForReaderView];
-    
+
     CGRect toolbarRect = viewRect; toolbarRect.size.height = TOOLBAR_HEIGHT;
-//    mainToolbar = [[ReaderMainToolbar alloc] initWithFrame:toolbarRect document:document]; // ReaderMainToolbar
+    //    mainToolbar = [[ReaderMainToolbar alloc] initWithFrame:toolbarRect document:document]; // ReaderMainToolbar
     mainToolbar = [[SDVReaderMainToolbar alloc] initWithFrame:toolbarRect document:document options:self.viewerOptions]; // customised ReaderMainToolbar
     mainToolbar.delegate = self; // ReaderMainToolbarDelegate
     [self.view addSubview:mainToolbar];
+    
+    // Add Swipe View
+    CGRect swipeViewRect = viewRect;
+    swipeViewRect.size.height = TOOLBAR_HEIGHT;
+    CGFloat screenWidth = self.view.frame.size.width;
+    swipeViewRect.origin.y = TOOLBAR_HEIGHT * 2;
+    swipeViewRect.origin.x = screenWidth/4;
+    swipeViewRect.size.width = screenWidth/2;
+    swipeForArticleView = [[UIView alloc] initWithFrame:swipeViewRect];
+    
+    swipeForArticleView.autoresizesSubviews = NO;
+    swipeForArticleView.userInteractionEnabled = NO;
+    swipeForArticleView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+    swipeForArticleView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.4f];
+    
+    swipeForArticleView.layer.shadowOffset = CGSizeMake(0.0f, 0.0f);
+    swipeForArticleView.layer.shadowColor = [UIColor colorWithWhite:0.0f alpha:0.6f].CGColor;
+    swipeForArticleView.layer.shadowPath = [UIBezierPath bezierPathWithRect:swipeForArticleView.bounds].CGPath;
+    swipeForArticleView.layer.shadowRadius = 2.0f; swipeForArticleView.layer.shadowOpacity = 1.0f;
+    
+    CGRect articleTextRect = CGRectInset(swipeForArticleView.bounds, 4.0f, 2.0f); // Inset the text a bit
+    
+    UILabel* articleTextLabel = [[UILabel alloc] initWithFrame:articleTextRect]; // Page numbers label
+    articleTextLabel.text = @"Swipe up for Reader View";
+    
+    articleTextLabel.autoresizesSubviews = NO;
+    articleTextLabel.autoresizingMask = UIViewAutoresizingNone;
+    articleTextLabel.textAlignment = NSTextAlignmentCenter;
+    articleTextLabel.backgroundColor = [UIColor clearColor];
+    articleTextLabel.textColor = [UIColor whiteColor];
+    articleTextLabel.font = [UIFont systemFontOfSize:16.0f];
+    articleTextLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
+    articleTextLabel.shadowColor = [UIColor blackColor];
+    articleTextLabel.adjustsFontSizeToFitWidth = YES;
+    articleTextLabel.minimumScaleFactor = 0.75f;
+    
+    [swipeForArticleView addSubview:articleTextLabel]; // Add label view
+    
+    [self.view addSubview:swipeForArticleView]; // swipe for article text.
     
     CGRect pagebarRect = self.view.bounds; pagebarRect.size.height = PAGEBAR_HEIGHT;
     pagebarRect.origin.y = (self.view.bounds.size.height - pagebarRect.size.height);
@@ -1203,7 +1205,7 @@
     [self.view addGestureRecognizer:doubleTapTwo];
     
     [singleTapOne requireGestureRecognizerToFail:doubleTapOne]; // Single tap requires double tap to fail
-
+    
 //    UISwipeGestureRecognizer *swipeUp = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipe:)];
 //    swipeUp.direction = UISwipeGestureRecognizerDirectionUp;
 //    [self.view addGestureRecognizer:swipeUp];

--- a/src/ios/vfr/SDVReaderViewController.m
+++ b/src/ios/vfr/SDVReaderViewController.m
@@ -1142,7 +1142,7 @@
     
     // Add Swipe View
     CGRect swipeViewRect = viewRect;
-    swipeViewRect.size.height = TOOLBAR_HEIGHT;
+    swipeViewRect.size.height = TOOLBAR_HEIGHT*0.75;
     CGFloat screenWidth = self.view.frame.size.width;
     swipeViewRect.origin.y = TOOLBAR_HEIGHT * 2;
     swipeViewRect.origin.x = screenWidth/4;

--- a/src/ios/vfr/SDVReaderViewController.m
+++ b/src/ios/vfr/SDVReaderViewController.m
@@ -141,10 +141,7 @@
         if ([self isCurrentPageArticle]) {
             [self showReaderViewSwipe];
         } else {
-            if (readerViewTimer != nil) {
-                [readerViewTimer invalidate];
-                readerViewTimer = nil;
-            }
+            [self invalidateTimer];
             swipeForArticleView.hidden = YES;
         }
     }
@@ -165,6 +162,11 @@
         }
      ];
     
+    [self invalidateTimer];
+}
+
+-(void)invalidateTimer
+{
     if (readerViewTimer != nil) {
         [readerViewTimer invalidate];
         readerViewTimer = nil;
@@ -176,10 +178,7 @@
     swipeForArticleView.alpha = 1.0f;
     swipeForArticleView.hidden = NO;
     
-    if (readerViewTimer != nil) {
-        [readerViewTimer invalidate];
-        readerViewTimer = nil;
-    }
+    [self invalidateTimer];
     readerViewTimer = [NSTimer scheduledTimerWithTimeInterval:3.0
                                                        target:self
                                                      selector:@selector(hideReaderViewSwipe)

--- a/src/ios/vfr/SDVReaderViewController.m
+++ b/src/ios/vfr/SDVReaderViewController.m
@@ -21,6 +21,7 @@
 
 @implementation SDVReaderViewController {
     SwipeDismissAnimationController* swipeDismissAnimationController;
+    NSTimer* readerViewTimer;
 }
 
 #pragma mark - Constants
@@ -137,7 +138,48 @@
     if ([mainPagebar isKindOfClass:[SDVReaderMainPagebar class]]) {
         SDVReaderMainPagebar* sdvPageBar = (SDVReaderMainPagebar *)mainPagebar;
         [sdvPageBar showSwipeForArticleViewLabel:[self isCurrentPageArticle]];
+        
+        if ([self isCurrentPageArticle]) {
+            [self showReaderViewSwipe];
+        } else {
+            [self hideReaderViewSwipe];
+        }
     }
+}
+
+-(void)hideReaderViewSwipe
+{
+    [UIView animateWithDuration:2.0 delay:0.0
+        options:UIViewAnimationOptionCurveLinear | UIViewAnimationOptionAllowUserInteraction
+                     animations:^(void)
+        {
+            swipeForArticleView.alpha = 0.0f;
+        }
+        completion:^(BOOL finished)
+        {
+            swipeForArticleView.hidden = YES;
+            swipeForArticleView.alpha = 1.0f;
+        }
+     ];
+    
+    if (readerViewTimer != nil) {
+        [readerViewTimer invalidate];
+    }
+}
+
+-(void)showReaderViewSwipe
+{
+    swipeForArticleView.alpha = 1.0f;
+    swipeForArticleView.hidden = NO;
+    
+    if (readerViewTimer != nil) {
+        [readerViewTimer invalidate];
+    }
+    readerViewTimer = [NSTimer scheduledTimerWithTimeInterval:5.0
+                                                       target:self
+                                                     selector:@selector(hideReaderViewSwipe)
+                                                     userInfo:nil
+                                                      repeats:NO];
 }
 
 //  override addContentView to use single or double page
@@ -388,6 +430,45 @@
 //         ];
 //    }
 //}
+
+-(void)addSwipeUpForReaderView
+{
+    CGFloat screenWidth = self.view.frame.size.width;
+    CGRect theFrame = self.view.frame;
+    CGRect swipeRect = CGRectMake(screenWidth/4, STATUS_HEIGHT*3 + 10, screenWidth/2.0, STATUS_HEIGHT);
+    swipeForArticleView = [[UIView alloc] initWithFrame:swipeRect];
+    
+    swipeForArticleView.autoresizesSubviews = NO;
+    swipeForArticleView.userInteractionEnabled = NO;
+    swipeForArticleView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+    swipeForArticleView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.4f];
+    
+    swipeForArticleView.layer.shadowOffset = CGSizeMake(0.0f, 0.0f);
+    swipeForArticleView.layer.shadowColor = [UIColor colorWithWhite:0.0f alpha:0.6f].CGColor;
+    swipeForArticleView.layer.shadowPath = [UIBezierPath bezierPathWithRect:swipeForArticleView.bounds].CGPath;
+    swipeForArticleView.layer.shadowRadius = 2.0f; swipeForArticleView.layer.shadowOpacity = 1.0f;
+    
+    CGRect articleTextRect = CGRectInset(swipeForArticleView.bounds, 4.0f, 2.0f); // Inset the text a bit
+    
+    UILabel* articleTextLabel = [[UILabel alloc] initWithFrame:articleTextRect]; // Page numbers label
+    articleTextLabel.text = @"Swipe up for Reader View";
+    
+    articleTextLabel.autoresizesSubviews = NO;
+    articleTextLabel.autoresizingMask = UIViewAutoresizingNone;
+    articleTextLabel.textAlignment = NSTextAlignmentCenter;
+    articleTextLabel.backgroundColor = [UIColor clearColor];
+    articleTextLabel.textColor = [UIColor whiteColor];
+    articleTextLabel.font = [UIFont systemFontOfSize:16.0f];
+    articleTextLabel.shadowOffset = CGSizeMake(0.0f, 1.0f);
+    articleTextLabel.shadowColor = [UIColor blackColor];
+    articleTextLabel.adjustsFontSizeToFitWidth = YES;
+    articleTextLabel.minimumScaleFactor = 0.75f;
+    
+    [swipeForArticleView addSubview:articleTextLabel]; // Add label view
+    
+    [self.view addSubview:swipeForArticleView]; // swipe for article text.
+
+}
 
 // individual page number calculations on scroll for double page modes
 - (void)handleScrollViewDidEnd:(UIScrollView *)scrollView
@@ -1087,6 +1168,9 @@
     theScrollView.backgroundColor = [UIColor blackColor]; theScrollView.delegate = self;
     [self.view addSubview:theScrollView];
     
+    // Add Swipe View
+    [self addSwipeUpForReaderView];
+    
     CGRect toolbarRect = viewRect; toolbarRect.size.height = TOOLBAR_HEIGHT;
 //    mainToolbar = [[ReaderMainToolbar alloc] initWithFrame:toolbarRect document:document]; // ReaderMainToolbar
     mainToolbar = [[SDVReaderMainToolbar alloc] initWithFrame:toolbarRect document:document options:self.viewerOptions]; // customised ReaderMainToolbar
@@ -1507,6 +1591,20 @@
 }
 
 #pragma mark - ReaderContentViewDelegate methods
+
+-(void)scrollViewEndedZoomingWithScrollView:(UIScrollView *)view atScale:(CGFloat)scale;
+{
+    // hide/show the swipe for article view based on zoom scale.
+    if (scale == view.minimumZoomScale) {
+        if ([self isCurrentPageArticle]) {
+            [self showReaderViewSwipe];
+        } else {
+            [self hideReaderViewSwipe];
+        }
+    } else {
+        swipeForArticleView.hidden = true;
+    }
+}
 
 #pragma mark - ReaderMainToolbarDelegate methods
 


### PR DESCRIPTION
Remove "Swipe up for Reader View" label view from ReaderMainToolbar, and add it to a 3 second timer near the top. When the user is on a PDF page where he/she can swipe for reader view, the "Swipe up for Reader View" text will appear for 3 seconds and then fade away. If the user zooms in, the text disappears and when the user zooms back out, the text reappears for 3 seconds. Changing pages also invalidates the timer.